### PR TITLE
Stop running matplotlib.use in module

### DIFF
--- a/fcn/utils.py
+++ b/fcn/utils.py
@@ -15,9 +15,6 @@ import tarfile
 import tempfile
 import zipfile
 
-import matplotlib
-if os.environ.get('DISPLAY', '') == '':  # NOQA
-    matplotlib.use('Agg')  # NOQA
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-chainer>=1.18.0
+chainer>=1.18.0,<1.20.0
 gdown>=3.2.3
 h5py>=2.2.1
 matplotlib>=1.3.1


### PR DESCRIPTION
Running `matplotlib.use` must be user-level code.

See https://github.com/pfnet/chainer/issues/2146