### PR TITLE
override __call__ in params_report

### DIFF
--- a/fcn/extensions/params_report.py
+++ b/fcn/extensions/params_report.py
@@ -11,6 +11,9 @@ class ParamsReport(training.Extension):
         self._params = params
         self._file_name = file_name
 
+    def __call__(self, trainer):
+        pass
+
     def initialize(self, trainer):
         print('# ' + '-' * 77)
         pprint.pprint(self._params)


### PR DESCRIPTION
this PR fix the issue reported in chainer-mask-rcnn: https://github.com/wkentaro/chainer-mask-rcnn/issues/40

this error is introduced in chainer `6.0.0`
https://github.com/chainer/chainer/pull/6095